### PR TITLE
Match input type to p-map and add more tests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import type {Options} from 'p-map';
+import type { Options } from "p-map";
 
 /**
 Filter promises concurrently.
@@ -74,7 +74,9 @@ for await (const element of pFilterIterable(places, filterer)) {
 ```
 */
 export function pFilterIterable<ValueType>(
-	input: Iterable<ValueType | PromiseLike<ValueType>>,
+	input:
+		| AsyncIterable<ValueType | PromiseLike<ValueType>>
+		| Iterable<ValueType | PromiseLike<ValueType>>,
 	filterer: (
 		element: ValueType,
 		index: number
@@ -82,4 +84,4 @@ export function pFilterIterable<ValueType>(
 	options?: Options
 ): AsyncIterable<ValueType>;
 
-export {Options} from 'p-map';
+export { Options } from "p-map";

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -22,6 +22,18 @@ expectType<AsyncIterable<string>>(
 	),
 );
 
+async function * getPlaces() {
+	yield 'Bangkok, Thailand';
+	yield 'Berlin, Germany';
+	yield 'Tokyo, Japan';
+}
+
+expectType<AsyncIterable<string>>(
+	pFilterIterable(getPlaces(), async place =>
+		place === 'Bangkok, Thailand' ? true : Promise.resolve(false),
+	),
+);
+
 expectType<AsyncIterable<number>>(
 	pFilterIterable(new Set([1, 2]), number => number > 1, {concurrency: 1}),
 );

--- a/test.js
+++ b/test.js
@@ -18,6 +18,15 @@ test('handles empty iterable', async t => {
 });
 
 test('pFilterIterable', async t => {
+	const iterableToArray = async iterable => {
+		const array = [];
+		for await (const item of iterable) {
+			array.push(item);
+		}
+
+		return array;
+	};
+
 	const rangeIterable = {
 		async * [Symbol.asyncIterator]() {
 			yield 1;
@@ -26,21 +35,29 @@ test('pFilterIterable', async t => {
 			yield 4;
 		},
 	};
-	const iterable = pFilterIterable(rangeIterable, x => x % 2);
-	const results = [];
-	for await (const x of iterable) {
-		results.push(x);
-	}
-
-	t.deepEqual(results, [1, 3]);
-
-	const iterable2 = pFilterIterable(rangeIterable, x =>
-		Promise.resolve(x % 2),
+	t.deepEqual(
+		await iterableToArray(pFilterIterable(rangeIterable, x => x % 2)),
+		[1, 3],
 	);
-	const results2 = [];
-	for await (const x of iterable2) {
-		results2.push(x);
-	}
 
-	t.deepEqual(results2, [1, 3]);
+	t.deepEqual(
+		await iterableToArray(
+			pFilterIterable(rangeIterable, x => Promise.resolve(x % 2)),
+		),
+		[1, 3],
+	);
+
+	t.deepEqual(
+		await iterableToArray(
+			pFilterIterable([Promise.resolve(1), 2, 3, 4], x => x % 2),
+		),
+		[1, 3],
+	);
+	t.deepEqual(
+		await iterableToArray(
+			pFilterIterable([1, 2, 3, 4], x => Promise.resolve(x % 2)),
+		),
+		[1, 3],
+	);
+	t.deepEqual(await iterableToArray(pFilterIterable([])), []);
 });


### PR DESCRIPTION
Hey,
Looks like I missed matching the input type to what we accept in `p-map` so I copied the type from there,
I also added more tests for types and tests for sync iterator that I assume should work based on the input type.

It seems that the tests fail now but I believe that there is an issue in `p-map`.
I'll reproduce the issue in the `p-map` repo and we can fix this PR by bumping,

Thanks